### PR TITLE
Log error from send simple command

### DIFF
--- a/src/mongo.zig
+++ b/src/mongo.zig
@@ -65,15 +65,21 @@ pub const MongoClient = struct {
 
         std.debug.print("Sending command {any} to database: {s}\n", .{ command.ptr.*, db_name });
 
+        var err: BsonError = .{};
         const result = mongoc.mongoc_client_command_simple(
             self.client,
             db_name,
             @ptrCast(command.ptr),
             null,
             @ptrCast(reply.?),
-            null,
+            @ptrCast(@alignCast(&err)),
         );
         if (!result) {
+            std.log.err("Simple Command Failed - {d}.{d}: {s}", .{
+                err.domain,
+                err.code,
+                @as([*c]u8, err.message[0 .. err.message.len - 1 :0]),
+            });
             return error.CommandFailed;
         }
         return reply.?.*;


### PR DESCRIPTION
I couldn't get the example running (looks like its because BSON_NEW is not completely implemented yet?).

I was curious what the error was so I hooked up the error argument. The error I'm seeing is 

```
error: Simple Command Failed - 11.22: Empty command document
```

I'm not sure this is something you wanted or not but putting up just incase. I'm assuming long term it would be better to propagate the error to the caller of `sendSimpleCommand`.